### PR TITLE
UIU-424: Updated tests to handle empty users list onload

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test-new-proxy": "./node_modules/.bin/mocha test-module.js --run=/users:new_proxy",
     "test-inventory": "./node_modules/.bin/mocha test-module.js --run=/inventory",
     "test-requests": "./node_modules/.bin/mocha test-module.js --run=/requests",
+    "test-users": "./node_modules/.bin/mocha test-module.js --run=/users",
     "test-module": "./node_modules/.bin/mocha test-module.js",
     "module-tests": "./node_modules/.bin/mocha test-module.js --run=/checkout/checkin/users/items/inventory",
     "lint": "eslint *.js test/*.js"

--- a/test/exercise.js
+++ b/test/exercise.js
@@ -58,6 +58,8 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
     it('should find an active user ', (done) => {
       nightmare
         .click('#clickable-users-module')
+        .wait(2000)
+        .click('#clickable-filter-active-Active')
         .wait(uselector)
         .evaluate(function (selector) {
           return document.querySelector(selector).title;


### PR DESCRIPTION
The Users module was changed to not show any users on initial load. This PR changes the tests to check the 'Active' filter to ensure that a list of users is fetched and displayed.