### PR TITLE
JIRA number FOLIO-1127 - test that turns on/off profile picture

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test-module": "./node_modules/.bin/mocha test-module.js",
     "module-tests": "./node_modules/.bin/mocha test-module.js --run=/checkout/checkin/users/items/inventory",
     "lint": "eslint *.js test/*.js",
-	"test-codexsearch": "./node_modules/.bin/mocha test/codex-search.js"
+	"test-codexsearch": "./node_modules/.bin/mocha test/codex-search.js",
+    "test-profilePictures": "./node_modules/.bin/mocha test/profile-pictures.js"
   },
   "dependencies": {
     "@folio/checkin": "latest",

--- a/test/profile-pictures.js
+++ b/test/profile-pictures.js
@@ -1,0 +1,136 @@
+/* global it describe */
+
+/*
+ Test for Settings > Users > Profile Picture
+ 1) login
+ 2) click settings
+ 3) click users
+ 4) profile pictures
+ 5) click "Display profile pictures" checkbox
+ 6) click save
+ 7) load users modules (click "Users" at top of screen)
+ 8) click a user from the user list (center pane)
+ 9) confirm that the full user record in the third pane has 100 x 100 pixel image in the "User information" section.
+ 10) go back to profile picture settings and uncheck "Display profile pictures"
+ 11) go back to a user record an confirm that 100 x 100 pixel image is not present.
+*/
+
+const Nightmare = require('nightmare');
+const config = require('../folio-ui.config.js');
+const helpers = require('../helpers.js');
+
+describe('Load test-profilePictures', function runMain() {
+  this.timeout(Number(config.test_timeout));
+
+  const nightmare = new Nightmare(config.nightmare);
+  const pageLoadPeriod = 2000;
+  const actionLoadPeriod = 222;
+  const imgWidth = 100;
+  const imgHeight = 100;
+
+  describe('Login > Settings > Enable Profile Pictures > Users > User Information has 100x100 px image > Disable Profile Pictures > Users > User Information does not have 100x100 px image > Logout\n', () => {
+    it(`should login as ${config.username}/${config.password}`, (done) => {
+      helpers.login(nightmare, config, done);
+    });
+
+    it('should enable profile pictures', (done) => {
+      nightmare
+        .on('console', (log, msg) => {
+          console.log(msg);
+        })
+        .click('#clickable-settings')
+        .wait(pageLoadPeriod)
+        .click('a[href="/settings/users"]')
+        .wait(actionLoadPeriod)
+        .click('a[href="/settings/users/profilepictures"]')
+        .wait(actionLoadPeriod)
+        .evaluate(() => {
+          const elem = document.querySelector('#profile_pictures');
+          if (!elem.checked) {
+            // not checked so check it and save
+            // elem.checked = true;
+            elem.click();
+            document.querySelector('#clickable-save-config').disabled = false;
+            document.querySelector('#clickable-save-config').click();
+          }
+        })
+        // .click('#profile_pictures')
+        // .wait('#clickable-save-config')
+        // .click('#clickable-save-config')
+        .wait(pageLoadPeriod)
+        .then(() => { done(); })
+        .catch(done);
+    });
+
+    it('should check picture present in user information', (done) => {
+      nightmare
+        .click('#clickable-users-module')
+        .wait('#Status-0')
+        // check on active users filter
+        .click('#clickable-filter-active-Active')
+        .wait('#list-users')
+        .click('#list-users div[role="listitem"]:first-of-type > a')
+        .wait('#userInformationSection')
+        .wait('#userInformationSection > div[role="tabpanel"] img')
+        .evaluate((imgW, imgH) => {
+          const imgElem = document.querySelector('#userInformationSection > div[role="tabpanel"] img');
+          if (imgElem === null) {
+            throw new Error('Image not being displayed');
+          }
+          console.log(imgElem.naturalWidth);
+          console.log(imgElem.naturalHeight);
+          if (imgElem.naturalWidth !== imgW && imgElem.naturalHeight !== imgH) {
+            throw new Error('Image displayed does not have the correct dimensions');
+          }
+        }, imgWidth, imgHeight)
+        .then(() => { done(); })
+        .catch(done);
+    });
+
+    it('should disable profile pictures', (done) => {
+      nightmare
+        .click('#clickable-settings')
+        .wait(pageLoadPeriod)
+        // .click('a[href="/settings/users"]')
+        // .wait(actionLoadPeriod)
+        // .click('a[href="/settings/users/profilepictures"]')
+        // .wait(actionLoadPeriod)
+        .evaluate(() => {
+          const elem = document.querySelector('#profile_pictures');
+          if (elem.checked) {
+            // checked so uncheck it and save
+            // elem.checked = false;
+            elem.click();
+            document.querySelector('#clickable-save-config').disabled = false;
+            document.querySelector('#clickable-save-config').click();
+          }
+        })
+        .wait(pageLoadPeriod)
+        .then(() => { done(); })
+        .catch(done);
+    });
+
+    it('should check picture not present in user information', (done) => {
+      nightmare
+        .click('#clickable-users-module')
+        .wait('#users-module-display')
+        // check on active users filter
+        .check('#clickable-filter-active-Active')
+        .wait('#list-users')
+        .click('#list-users div[role="listitem"]:first-of-type > a')
+        .wait('#userInformationSection')
+        .evaluate(() => {
+          const img = document.querySelector('#userInformationSection > div[role="tabpanel"] img');
+          if (img !== null) {
+            throw new Error('Image is being displayed');
+          }
+        })
+        .then(() => { done(); })
+        .catch(done);
+    });
+
+    it('should logout', (done) => {
+      helpers.logout(nightmare, config, done);
+    });
+  });
+});

--- a/test/profile-pictures.js
+++ b/test/profile-pictures.js
@@ -35,9 +35,6 @@ describe('Load test-profilePictures', function runMain() {
 
     it('should enable profile pictures', (done) => {
       nightmare
-        .on('console', (log, msg) => {
-          console.log(msg);
-        })
         .click('#clickable-settings')
         .wait(pageLoadPeriod)
         .click('a[href="/settings/users"]')
@@ -62,6 +59,22 @@ describe('Load test-profilePictures', function runMain() {
         .catch(done);
     });
 
+    it('should check that profile pictures are enabled', (done) => {
+      nightmare
+        .click('a[href="/settings/users"]')
+        .wait(actionLoadPeriod)
+        .click('a[href="/settings/users/profilepictures"]')
+        .wait(actionLoadPeriod)
+        .evaluate(() => {
+          const elem = document.querySelector('#profile_pictures');
+          if (!elem.checked) {
+            throw new Error('Profile pictures not enabled');
+          }
+        })
+        .then(() => { done(); })
+        .catch(done);
+    });
+
     it('should check picture present in user information', (done) => {
       nightmare
         .click('#clickable-users-module')
@@ -69,16 +82,18 @@ describe('Load test-profilePictures', function runMain() {
         // check on active users filter
         .click('#clickable-filter-active-Active')
         .wait('#list-users')
+        .wait(pageLoadPeriod)
         .click('#list-users div[role="listitem"]:first-of-type > a')
+        .wait(pageLoadPeriod)
         .wait('#userInformationSection')
-        .wait('#userInformationSection > div[role="tabpanel"] img')
+        .wait(pageLoadPeriod)
         .evaluate((imgW, imgH) => {
           const imgElem = document.querySelector('#userInformationSection > div[role="tabpanel"] img');
           if (imgElem === null) {
             throw new Error('Image not being displayed');
           }
-          console.log(imgElem.naturalWidth);
-          console.log(imgElem.naturalHeight);
+          // console.log(imgElem.naturalWidth);
+          // console.log(imgElem.naturalHeight);
           if (imgElem.naturalWidth !== imgW && imgElem.naturalHeight !== imgH) {
             throw new Error('Image displayed does not have the correct dimensions');
           }
@@ -91,10 +106,6 @@ describe('Load test-profilePictures', function runMain() {
       nightmare
         .click('#clickable-settings')
         .wait(pageLoadPeriod)
-        // .click('a[href="/settings/users"]')
-        // .wait(actionLoadPeriod)
-        // .click('a[href="/settings/users/profilepictures"]')
-        // .wait(actionLoadPeriod)
         .evaluate(() => {
           const elem = document.querySelector('#profile_pictures');
           if (elem.checked) {
@@ -110,6 +121,22 @@ describe('Load test-profilePictures', function runMain() {
         .catch(done);
     });
 
+    it('should check that profiel pictures is disabled', (done) => {
+      nightmare
+        .click('a[href="/settings/users"]')
+        .wait(actionLoadPeriod)
+        .click('a[href="/settings/users/profilepictures"]')
+        .wait(actionLoadPeriod)
+        .evaluate(() => {
+          const elem = document.querySelector('#profile_pictures');
+          if (elem.checked) {
+            throw new Error('Profile pictures still enabled');
+          }
+        })
+        .then(() => { done(); })
+        .catch(done);
+    });
+
     it('should check picture not present in user information', (done) => {
       nightmare
         .click('#clickable-users-module')
@@ -118,7 +145,9 @@ describe('Load test-profilePictures', function runMain() {
         .check('#clickable-filter-active-Active')
         .wait('#list-users')
         .click('#list-users div[role="listitem"]:first-of-type > a')
+        .wait(pageLoadPeriod)
         .wait('#userInformationSection')
+        .wait(pageLoadPeriod)
         .evaluate(() => {
           const img = document.querySelector('#userInformationSection > div[role="tabpanel"] img');
           if (img !== null) {


### PR DESCRIPTION
I've increased some timeouts and changed the waiting on other selectors. I noticed sometimes the save to enable profile pictures does not keep the new setting. I've added a test after enabling the setting to check that it was enabled before checking for the profile pictures. 