### PR TITLE
prefer metadata over metaData. Fixes UITEST-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.2.0 (IN PROGRESS)
 * Change @folio dependencies to * for access to local checkouts. Refs UITEST-21. 
 * Ignore yarn-error.log. Refs STRIPES-517.
+* Prefer metadata to metaData for consistency. Fixes UITEST-24. 
 
 ## [4.1.0](https://github.com/folio-org/ui-testing/tree/v4.0.0) (2017-09-01)
 

--- a/helpers.js
+++ b/helpers.js
@@ -31,10 +31,10 @@ module.exports.openApp = (nightmare, config, done, app, testVersion) => function
     .click(`#clickable-${app}-module`)
     .wait(`#${app}-module-display`)
     .evaluate((mapp) => {
-      const metaData = document.querySelector(`#${mapp}-module-display`);
+      const metadata = document.querySelector(`#${mapp}-module-display`);
       return {
-        moduleName: metaData.getAttribute('data-module'),
-        moduleVersion: metaData.getAttribute('data-version'),
+        moduleName: metadata.getAttribute('data-module'),
+        moduleVersion: metadata.getAttribute('data-version'),
       };
     }, app)
     .then((meta) => {


### PR DESCRIPTION
Fixes [UITEST-24](https://issues.folio.org/browse/UITEST-24). 

Geez this is pedantic, but given the pain that converting `metaData` to `metadata` has been in our APIs, it seems like a good idea to just enforce that convention everywhere so pEoPLe don'T jusT capItalize WhatEver tHEy feeL Like. 