### PR TITLE
don't use 'Active' filter; it's deprecated

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -144,7 +144,7 @@ module.exports.namegen = () => {
     firstname,
     lastname,
     email: `${firstname.toLowerCase()}.${lastname.toLowerCase()}@someserver.org`,
-    barcode: ts,
+    barcode: `0${ts}`,
     password: 'P@$$w0rd23',
     address: ad[adpos],
   };

--- a/test/exercise.js
+++ b/test/exercise.js
@@ -58,7 +58,8 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait(2000)
-        .click('#clickable-filter-active-Active')
+        .wait('#input-user-search')
+        .type('#input-user-search', '0')
         .wait(uselector)
         .evaluate(selector => document.querySelector(selector).title, uselector)
         .then((result) => {
@@ -186,8 +187,10 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
-      // .click('#input-user-search ~ div button')
-        .wait(222)
+        .type('#input-user-search', '0')
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
+        .wait(1000)
         .insert('#input-user-search', userid)
         .wait(`#list-users div[title="${userid}"]`)
         .click(`#list-users div[title="${userid}"]`)
@@ -226,7 +229,9 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
-      // .click('#input-user-search ~ div button')
+        .type('#input-user-search', '0')
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
         .insert('#input-user-search', userid)
         .wait(`div[title="${userid}"]`)
         .click(`div[title="${userid}"]`)

--- a/test/profile-pictures.js
+++ b/test/profile-pictures.js
@@ -79,9 +79,8 @@ describe('Load test-profilePictures', function runMain() {
     it('should check picture present in user information', (done) => {
       nightmare
         .click('#clickable-users-module')
-        .wait('#clickable-filter-active-Active')
-        // check on active users filter
-        .click('#clickable-filter-active-Active')
+        .wait('#input-user-search')
+        .type('#input-user-search', '0')
         .wait('#list-users')
         .wait('#list-users div[role="listitem"]:first-of-type > a')
         .click('#list-users div[role="listitem"]:first-of-type > a')
@@ -143,7 +142,8 @@ describe('Load test-profilePictures', function runMain() {
         .click('#clickable-users-module')
         .wait('#users-module-display')
         // check on active users filter
-        .check('#clickable-filter-active-Active')
+        .wait('#input-user-search')
+        .type('#input-user-search', '0')
         .wait('#list-users')
         .click('#list-users div[role="listitem"]:first-of-type > a')
         .wait('#userInformationSection > div[role="tabpanel"]')


### PR DESCRIPTION
The active/inactive users filters are deprecated and will be replaced
with a single "Show inactive users" filter; active users will be
returned in all search/filter results. Prefix new user-barcodes with a
'0' to make them findable since it will no longer be possible to
retrieve them with the 'Active' filter. Enter a '0' as a search in order
to show the 'Reset all' button which then allows the form to be
completely cleared prior to subsequent searches.

Refs [UIU-400](https://issues.folio.org/browse/UIU-400)