### PR TITLE
Revert "don't use 'Active' filter; it's deprecated"

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -144,7 +144,7 @@ module.exports.namegen = () => {
     firstname,
     lastname,
     email: `${firstname.toLowerCase()}.${lastname.toLowerCase()}@someserver.org`,
-    barcode: `0${ts}`,
+    barcode: ts,
     password: 'P@$$w0rd23',
     address: ad[adpos],
   };

--- a/test/exercise.js
+++ b/test/exercise.js
@@ -58,8 +58,7 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait(2000)
-        .wait('#input-user-search')
-        .type('#input-user-search', '0')
+        .click('#clickable-filter-active-Active')
         .wait(uselector)
         .evaluate(selector => document.querySelector(selector).title, uselector)
         .then((result) => {
@@ -187,10 +186,8 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
-        .type('#input-user-search', '0')
-        .wait('#clickable-reset-all')
-        .click('#clickable-reset-all')
-        .wait(1000)
+      // .click('#input-user-search ~ div button')
+        .wait(222)
         .insert('#input-user-search', userid)
         .wait(`#list-users div[title="${userid}"]`)
         .click(`#list-users div[title="${userid}"]`)
@@ -229,9 +226,7 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
-        .type('#input-user-search', '0')
-        .wait('#clickable-reset-all')
-        .click('#clickable-reset-all')
+      // .click('#input-user-search ~ div button')
         .insert('#input-user-search', userid)
         .wait(`div[title="${userid}"]`)
         .click(`div[title="${userid}"]`)

--- a/test/profile-pictures.js
+++ b/test/profile-pictures.js
@@ -79,8 +79,9 @@ describe('Load test-profilePictures', function runMain() {
     it('should check picture present in user information', (done) => {
       nightmare
         .click('#clickable-users-module')
-        .wait('#input-user-search')
-        .type('#input-user-search', '0')
+        .wait('#clickable-filter-active-Active')
+        // check on active users filter
+        .click('#clickable-filter-active-Active')
         .wait('#list-users')
         .wait('#list-users div[role="listitem"]:first-of-type > a')
         .click('#list-users div[role="listitem"]:first-of-type > a')
@@ -142,8 +143,7 @@ describe('Load test-profilePictures', function runMain() {
         .click('#clickable-users-module')
         .wait('#users-module-display')
         // check on active users filter
-        .wait('#input-user-search')
-        .type('#input-user-search', '0')
+        .check('#clickable-filter-active-Active')
         .wait('#list-users')
         .click('#list-users div[role="listitem"]:first-of-type > a')
         .wait('#userInformationSection > div[role="tabpanel"]')


### PR DESCRIPTION
Reverts folio-org/ui-testing#38

The active/inactive users filters _will be_ deprecated, but they aren't yet because the [UIU-400](https://issues.folio.org/browse/UIU-400)-related changes in ui-users itself haven't been merged. Until they are, existing tests must be left as-is. 