### PR TITLE
Utest 26

### DIFF
--- a/test/codex-search.js
+++ b/test/codex-search.js
@@ -4,6 +4,54 @@ const Nightmare = require('nightmare');
 const config = require('../folio-ui.config.js');
 const helpers = require('../helpers.js');
 
+
+Nightmare.action('waitUntilNetworkIdle',
+  // The first callback defines the action on Electron's end,
+  // making some internal objects available.
+  function (name, options, parent, win, renderer, done) {
+
+    // `parent` is Electron's reference to the object that
+    // passes messages between Electron and Nightmare.
+    parent.respondTo('waitUntilNetworkIdle', (waitTime, done) => {
+      let lastRequestTime = Date.now();
+
+      // win.webContents allows us to control the internal
+      // Electron BrowserWindow instance.
+      win.webContents.on('did-get-response-details', () => {
+        lastRequestTime = Date.now();
+      });
+
+      const check = () => {
+        const now = Date.now();
+        const elapsedTime = now - lastRequestTime;
+        if (elapsedTime >= waitTime) {
+          done(); // Complete the action.
+        } else {
+          setTimeout(check, waitTime - elapsedTime);
+        }
+      }
+      setTimeout(check, waitTime);
+    });
+
+    done(); // Complete the action's *creation*.
+  },
+  // The second callback runs on Nightmare's end and determines
+  // the action's interface.
+  function (waitTime, done) {
+    // This is necessary because the action will only work if
+    // action arguments are specified before `done`, and because
+    // we wish to support calls without arguments.
+    if (!done) {
+      done = waitTime;
+      waitTime = 500;
+    }
+
+    // `this.child` is Nightmare's reference to the object that
+    // passes messages between Electron and Nightmare.
+    this.child.call('waitUntilNetworkIdle', waitTime, done);
+  });
+
+
 describe('Load test-codexsearch', function runMain() {
   this.timeout(Number(config.test_timeout));
 
@@ -57,7 +105,7 @@ describe('Load test-codexsearch', function runMain() {
 
           nightmare
             .click(filterCheckBoxSelector)
-            .wait(10000)
+            .waitUntilNetworkIdle(actionLoadPeriod, done)
             .evaluate((filterCheckBoxSelector, resultSelectorAfterClick)=>{
 
               const filterCheckBox = document.querySelector(filterCheckBoxSelector);

--- a/test/codex-search.js
+++ b/test/codex-search.js
@@ -170,6 +170,12 @@ describe('Load test-codexsearch', function runMain() {
             }
           });
         }, resetButtonLabel, resetButtonSelector)
+        .evaluate(function confResetOfFilters(resetSelector) {
+          const filterCheckBox = document.querySelector(resetSelector);
+          if(filterCheckBox.checked) {
+            throw new Error('Filters have not been reset.');
+          }
+        }, filterCheckBoxSelector)
         .then((result) => { done(); })
         .catch(done);
     });


### PR DESCRIPTION
resolves [UITEST-26](https://issues.folio.org/browse/UITEST-26)

This PR includes:

- A test for sorting
- A test for filtering
- An additional evaluation within the reset confirmation test to confirm that filters have been reset.

The test for sorting has been commented out, since it is not currently passing. I have confirmed that sorting on title is in-fact not working, and reopened an associated issue: [FOLIO-1149](https://issues.folio.org/browse/FOLIO-1149).

Once this is resolved, the sorting test should be un-commented and should pass.

This also includes a custom action, waitUntilNetworkIdle, which is registered with nightmare. This file is not the ideal place for this, as this action may have utility in other tests.