### PR TITLE
initialize user search form before use

### DIFF
--- a/test/loan_renewal.js
+++ b/test/loan_renewal.js
@@ -150,6 +150,9 @@ describe('Tests to validate the loan renewals', function descRoot() {
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
+        .type('#input-user-search', '0')
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
         .wait(222)
         .insert('#input-user-search', userid)
         .wait(`#list-users div[title="${userid}"]`)


### PR DESCRIPTION
Clear the search form before entering a new search term. You never know
what cached data may be lurking there.