### PR TITLE
Reset user SearchField before entering userId

### DIFF
--- a/test/exercise.js
+++ b/test/exercise.js
@@ -126,8 +126,9 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
-      // .click('#input-user-search ~ div button')
-        .wait(222)
+        .insert('#input-user-search', userid)
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
         .insert('#input-user-search', userid)
         .wait(`#list-users div[title="${userid}"]`)
         .click(`#list-users div[title="${userid}"]`)
@@ -141,6 +142,8 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
             return false;
           }
         }, barcode)
+        .wait('div[class*="LayerRoot"] button[class*="paneHeaderCloseIcon"]')
+        .click('div[class*="LayerRoot"] button[class*="paneHeaderCloseIcon"]')
         .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging
         .then(done)
         .catch(done);
@@ -166,7 +169,9 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
       nightmare
         .click('#clickable-users-module')
         .wait('#input-user-search')
-      // .click('#input-user-search ~ div button')
+        .insert('#input-user-search', userid)
+        .wait('#clickable-reset-all')
+        .click('#clickable-reset-all')
         .insert('#input-user-search', userid)
         .wait(`div[title="${userid}"]`)
         .click(`div[title="${userid}"]`)
@@ -180,6 +185,8 @@ describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise
             return false;
           }
         }, barcode)
+        .wait('div[class*="LayerRoot"] button[class*="paneHeaderCloseIcon"]')
+        .click('div[class*="LayerRoot"] button[class*="paneHeaderCloseIcon"]')
         .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging
         .then(done)
         .catch(done);


### PR DESCRIPTION
- By the last test, it was searching for users with queries like "0dustindustin" which would predictably fail to find a user. Added a reset to ensure we'd only search for "dustin".
- The loans pane was obscuring the work in progress (and theoretically could cause issues down the line) so I added `.click`s to close them when we were done with them.