### PR TITLE
Update docs to not have outdated references to "active" users checkbox

### DIFF
--- a/doc/differences-in-stripes-components-testing.md
+++ b/doc/differences-in-stripes-components-testing.md
@@ -19,15 +19,15 @@ The application tests are full of sequences like the following (from [`ui-users/
 
 	.click('#clickable-users-module')
 	.wait(1000)
-	.click('#clickable-filter-active-Active')
+	.click('#clickable-filter-pg-faculty')
 
 This waits for a fixed period of 1000 ms for the results of the first click to take place before attempting the second click, which is both slow and unreliable: it will fail if, for some reason, it takes more than a second for the click to take effect.
 
 Instead, the stripes-component tests wait for the required element to become available:
 
 	.click('#clickable-users-module')
-	.wait('#clickable-filter-active-Active')
-	.click('#clickable-filter-active-Active')
+	.wait('#clickable-filter-pg-faculty')
+	.click('#clickable-filter-pg-faculty')
 
 There is no reason why the application tests should not be using this form, in at least most cases. (There may be some specific difficult cases where timed delays are necessary; these should be considered on their merits.)
 

--- a/test/profile-pictures.js
+++ b/test/profile-pictures.js
@@ -79,9 +79,8 @@ describe('Load test-profilePictures', function runMain() {
     it('should check picture present in user information', (done) => {
       nightmare
         .click('#clickable-users-module')
-        .wait('#clickable-filter-active-Active')
-        // check on active users filter
-        .click('#clickable-filter-active-Active')
+        .wait('#clickable-filter-pg-faculty')
+        .click('#clickable-filter-pg-faculty')
         .wait('#list-users')
         .wait('#list-users div[role="listitem"]:first-of-type > a')
         .click('#list-users div[role="listitem"]:first-of-type > a')
@@ -143,7 +142,8 @@ describe('Load test-profilePictures', function runMain() {
         .click('#clickable-users-module')
         .wait('#users-module-display')
         // check on active users filter
-        .check('#clickable-filter-active-Active')
+        .wait('#clickable-filter-pg-faculty')
+        .click('#clickable-filter-pg-faculty')
         .wait('#list-users')
         .click('#list-users div[role="listitem"]:first-of-type > a')
         .wait('#userInformationSection > div[role="tabpanel"]')


### PR DESCRIPTION
The "Active" checkbox no longer exists so we shouldn't wait for it to be in place before clicking and selecting from the (no longer automatically shown) list of users.