### PR TITLE
remove calls to relocated tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test-exercise": "./node_modules/.bin/mocha test/exercise.js",
     "test-loan-renewals": "./node_modules/.bin/mocha test/loan_renewal.js",
     "test-dependencies": "./node_modules/.bin/mocha test/dependencies.js",
-    "test-new-proxy": "./node_modules/.bin/mocha test-module.js --run=/users:new_proxy",
     "test-inventory": "./node_modules/.bin/mocha test-module.js --run=/inventory",
     "test-requests": "./node_modules/.bin/mocha test-module.js --run=/requests",
     "test-users": "./node_modules/.bin/mocha test-module.js --run=/users",


### PR DESCRIPTION
new_proxy.js, an integration test, has moved from ui-users to
platform-core because only unit tests should be included within their
modules in order for that module to be testable in isolation.

Refs [UIU-605](https://issues.folio.org/browse/UIU-605)